### PR TITLE
Fix .MSG files (MS Outlook Mail Exports)

### DIFF
--- a/src/ApacheMimetypeHelper.php
+++ b/src/ApacheMimetypeHelper.php
@@ -128,6 +128,7 @@ class ApacheMimetypeHelper implements MimetypeHelper
             'yaml' => 'text/yaml',
             'yml' => 'text/yaml',
             'zip' => 'application/zip',
+            'msg' => 'application/vnd.ms-outlook',
         ];
 
         $extension = strtolower($extension);


### PR DESCRIPTION
.MSG files contain multipart data since they are raw dumps of an e-mail. Mail API's like [mailgun](https://github.com/mailgun/mailgun-php) will send corrupt .msg attachments when the attachment is using the _default_ mimetype.
