### PR TITLE
Added custom mimetype helper

### DIFF
--- a/src/CustomMimetypeHelper.php
+++ b/src/CustomMimetypeHelper.php
@@ -3,7 +3,7 @@
 namespace Http\Message\MultipartStream;
 
 /**
- * Let you add your own mimetypes.
+ * Let you add your own mimetypes. The mimetype lookup will fallback on the ApacheMimeTypeHelper.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
@@ -15,7 +15,7 @@ class CustomMimetypeHelper extends ApacheMimetypeHelper
     private $mimetypes = [];
 
     /**
-     * @param array $mimetypes
+     * @param array $mimetypes should be of type extension => mimetype
      */
     public function __construct(array $mimetypes = [])
     {

--- a/src/CustomMimetypeHelper.php
+++ b/src/CustomMimetypeHelper.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Http\Message\MultipartStream;
+
+/**
+ * Let you add your own mimetypes.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class CustomMimetypeHelper extends ApacheMimetypeHelper
+{
+    /**
+     * @var array
+     */
+    private $mimetypes = [];
+
+    /**
+     * @param array $mimetypes
+     */
+    public function __construct(array $mimetypes = [])
+    {
+        $this->mimetypes = $mimetypes;
+    }
+
+    /**
+     * @param string $extension
+     * @param string $mimetype
+     *
+     * @return $this
+     */
+    public function addMimetype($extension, $mimetype)
+    {
+        $this->mimetypes[$extension] = $mimetype;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Check if we have any defined mimetypes and of not fallback to ApacheMimetypeHelper
+     */
+    public function getMimetypeFromExtension($extension)
+    {
+        $extension = strtolower($extension);
+
+        return isset($this->mimetypes[$extension])
+            ? $this->mimetypes[$extension]
+            : parent::getMimetypeFromExtension($extension);
+    }
+}

--- a/tests/CustomMimetypeHelperTest.php
+++ b/tests/CustomMimetypeHelperTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace tests\Http\Message\MultipartStream;
+
+use Http\Message\MultipartStream\CustomMimetypeHelper;
+
+class CustomMimetypeHelperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetMimetypeFromExtension()
+    {
+        $helper = new CustomMimetypeHelper(['foo'=>'foo/bar']);
+        $this->assertEquals('foo/bar', $helper->getMimetypeFromExtension('foo'));
+
+        $this->assertEquals('application/x-rar-compressed', $helper->getMimetypeFromExtension('rar'));
+        $helper->addMimetype('rar', 'test/test');
+        $this->assertEquals('test/test', $helper->getMimetypeFromExtension('rar'));
+    }
+}


### PR DESCRIPTION
This will fix #10 

Is this overkill? I thought about adding this features to ApacheMimeTypeHelper but that makes no sense since you still have to use `MultipartStreamBuilder::setMimetypeHelper`. Or maybe Im wrong..

Anyhow. This is a way for application developers to extend the MimeTypeHelper without adding new classes. 