### PR TITLE
Added support for multipart stream created from uri streams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.4",
         "php-http/message": "^1.0",
-        "zendframework/zend-diactoros": "^1.3.5"
+        "guzzlehttp/psr7": "^1.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.4",
         "php-http/message": "^1.0",
-        "guzzlehttp/psr7": "^1.3.1"
+        "zendframework/zend-diactoros": "^1.3.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -95,7 +95,14 @@ class MultipartStreamBuilder
                 $this->getHeaders($data['headers'])."\r\n";
 
             // Convert the stream to string
-            $streams .= (string) $data['contents'];
+            /* @var $contentStream StreamInterface */
+            $contentStream = $data['contents'];
+            if ($contentStream->isSeekable()) {
+                $streams .= (string) $data['contents'];
+            } else {
+                $streams .= $contentStream->getContents();
+            }
+
             $streams .= "\r\n";
         }
 

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -98,7 +98,7 @@ class MultipartStreamBuilder
             /* @var $contentStream StreamInterface */
             $contentStream = $data['contents'];
             if ($contentStream->isSeekable()) {
-                $streams .= (string) $data['contents'];
+                $streams .= $contentStream->__toString();
             } else {
                 $streams .= $contentStream->getContents();
             }

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -35,17 +35,18 @@ class FunctionTest extends \PHPUnit_Framework_TestCase
 
     public function testSupportURIResources()
     {
+        $url = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
+        $resource = fopen($url, 'r');
+
         $builder = new MultipartStreamBuilder();
-        $resource = 'https://raw.githubusercontent.com/php-http/multipart-stream-builder/master/tests/Resources/httplug.png';
-        $stream = fopen($resource, 'r');
-        $builder->addResource('image', $stream);
+        $builder->addResource('image', $resource);
         $multipartStream = (string) $builder->build();
 
         $this->assertTrue(false !== strpos($multipartStream, 'Content-Disposition: form-data; name="image"; filename="httplug.png"'));
         $this->assertTrue(false !== strpos($multipartStream, 'Content-Type: image/png'));
 
-        $uriResourceContents = file_get_contents($resource);
-        $this->assertContains($uriResourceContents, $multipartStream);
+        $urlContents = file_get_contents($url);
+        $this->assertContains($urlContents, $multipartStream);
     }
 
     public function testResourceFilenameIsNotLocaleAware()

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -3,7 +3,7 @@
 namespace tests\Http\Message\MultipartStream;
 
 use Http\Message\MultipartStream\MultipartStreamBuilder;
-
+use Zend\Diactoros\Stream;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -15,7 +15,7 @@ class FunctionTest extends \PHPUnit_Framework_TestCase
         $body = 'stream contents';
 
         $builder = new MultipartStreamBuilder();
-        $builder->addResource('foobar', $body);
+        $builder->addResource('foobar', $this->createStream($body));
 
         $multipartStream = (string) $builder->build();
         $this->assertTrue(false !== strpos($multipartStream, $body));
@@ -130,5 +130,19 @@ class FunctionTest extends \PHPUnit_Framework_TestCase
         $this->assertNotContains('foobar', $multipartStream, 'Stream should not have any data after reset()');
         $this->assertNotEquals($boundary, $builder->getBoundary(), 'Stream should have a new boundary after reset()');
         $this->assertNotEmpty($builder->getBoundary());
+    }
+
+    /**
+     * @param string $body
+     *
+     * @return Stream
+     */
+    private function createStream($body)
+    {
+        $stream = new Stream('php://memory', 'rw');
+        $stream->write($body);
+        $stream->rewind();
+
+        return $stream;
     }
 }


### PR DESCRIPTION
Added support for multipart uri streams by ensuring content from non-seekable streams is not fetched using string casting.

Added testSupportURIResources phpUnit test validating the multipart stream created from an uri resource.
Changed composer dev requirement zendframework/zend-diactoros for guzzlehttp/psr7 due to the fact that zend-diactoros DiactorosStreamFactory's createStream function runs a rewind which throws an exception if stream is not seekable.
Removed dependency on Zend\Diactoros\Stream in unit tests.