### PR TITLE
Use uniqid('', true) for performance reasons

### DIFF
--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -91,7 +91,7 @@ class MultipartStreamBuilder
         $streams = '';
         foreach ($this->data as $data) {
             // Add start and headers
-            $streams .= "--{$this->getBoundary()}\r\n".
+            $streams .= "--\"{$this->getBoundary()}\"\r\n".
                 $this->getHeaders($data['headers'])."\r\n";
 
             // Convert the stream to string
@@ -100,7 +100,7 @@ class MultipartStreamBuilder
         }
 
         // Append end
-        $streams .= "--{$this->getBoundary()}--\r\n";
+        $streams .= "--\"{$this->getBoundary()}\"--\r\n";
 
         return $this->streamFactory->createStream($streams);
     }
@@ -185,7 +185,7 @@ class MultipartStreamBuilder
     public function getBoundary()
     {
         if ($this->boundary === null) {
-            $this->boundary = uniqid();
+            $this->boundary = uniqid('', true);
         }
 
         return $this->boundary;


### PR DESCRIPTION
Why: http://blog.kevingomez.fr/til/2015/07/26/why-is-uniqid-slow/

See: https://github.com/guzzle/psr7/pull/133