### PR TITLE
Boundery should only be quoted in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.1.5 - 2017-02-16
+
+### Fixed
+
+- Performance improvements by avoid using `uniqid()`. 
+
 ## 0.1.5 - 2017-02-14
 
 ### Fixed

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -91,7 +91,7 @@ class MultipartStreamBuilder
         $streams = '';
         foreach ($this->data as $data) {
             // Add start and headers
-            $streams .= "--\"{$this->getBoundary()}\"\r\n".
+            $streams .= "--{$this->getBoundary()}\r\n".
                 $this->getHeaders($data['headers'])."\r\n";
 
             // Convert the stream to string
@@ -107,7 +107,7 @@ class MultipartStreamBuilder
         }
 
         // Append end
-        $streams .= "--\"{$this->getBoundary()}\"--\r\n";
+        $streams .= "--{$this->getBoundary()}--\r\n";
 
         return $this->streamFactory->createStream($streams);
     }


### PR DESCRIPTION
I also added readme. 

This is tested with mailgun