### PR TITLE
Fixed typos

### DIFF
--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -19,7 +19,7 @@ use Psr\Http\Message\StreamInterface;
 class MultipartStreamBuilder
 {
     /**
-     * @var StreamFactory|StreamFactoryInterface
+     * @var HttplugStreamFactory|StreamFactoryInterface
      */
     private $streamFactory;
 
@@ -39,7 +39,7 @@ class MultipartStreamBuilder
     private $data = [];
 
     /**
-     * @param StreamFactory|StreamFactoryInterface|null $streamFactory
+     * @param HttplugStreamFactory|StreamFactoryInterface|null $streamFactory
      */
     public function __construct($streamFactory = null)
     {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

Fixes typos causing PHPStan to be sad when analyzing my project:

```
  97     Parameter #1 $streamFactory of class Http\Message\MultipartStream\MultipartStreamBuilder constructor expects  
         Http\Message\MultipartStream\StreamFactory|Psr\Http\Message\StreamFactoryInterface|null,                      
         Http\Message\StreamFactory given.                                                                             
  136    Parameter #1 $streamFactory of class Http\Message\MultipartStream\MultipartStreamBuilder constructor expects  
         Http\Message\MultipartStream\StreamFactory|Psr\Http\Message\StreamFactoryInterface|null,                      
         Http\Message\StreamFactory given.   
```

---

Closes #41.