### PR TITLE
Allow MultipartStreamBuilder subclass to manipulate data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -73,6 +73,23 @@ class MultipartStreamBuilder
     }
 
     /**
+     * Add a resource to the Multipart Stream
+     *
+     * @param string|resource|\Psr\Http\Message\StreamInterface $resource
+     *     The filepath, resource or StreamInterface of the data.
+     * @param array $headers
+     *     Additional headers array: ['header-name' => 'header-value'].
+     *
+     * @return MultipartStreamBuilder
+     */
+    public function addData($resource, array $headers = [])
+    {
+        $stream = $this->createStream($resource);
+        $this->data[] = ['contents' => $stream, 'headers' => $headers];
+        return $this;
+    }
+
+    /**
      * Add a resource to the Multipart Stream.
      *
      * @param string                          $name     the formpost name

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -86,6 +86,7 @@ class MultipartStreamBuilder
     {
         $stream = $this->createStream($resource);
         $this->data[] = ['contents' => $stream, 'headers' => $headers];
+
         return $this;
     }
 
@@ -121,8 +122,8 @@ class MultipartStreamBuilder
         }
 
         $this->prepareHeaders($name, $stream, $options['filename'], $options['headers']);
-        $this->addData($stream, $options['headers']);
-        return $this;
+
+        return $this->addData($stream, $options['headers']);
     }
 
     /**

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -34,7 +34,7 @@ class MultipartStreamBuilder
     private $boundary;
 
     /**
-     * @var array Element where each Element is an array with keys ['contents', 'headers', 'filename']
+     * @var array Element where each Element is an array with keys ['contents', 'headers']
      */
     private $data = [];
 
@@ -121,8 +121,7 @@ class MultipartStreamBuilder
         }
 
         $this->prepareHeaders($name, $stream, $options['filename'], $options['headers']);
-        $this->data[] = ['contents' => $stream, 'headers' => $options['headers'], 'filename' => $options['filename']];
-
+        $this->addData($stream, $options['headers']);
         return $this;
     }
 


### PR DESCRIPTION
* Change property $data visibility from "private" to "protected".
  Leaving more flexibilities for subclassing.

| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   | This is one simple signature change for subclassing.
| License         | MIT


#### What's in this PR?

Allow subclass of MultipartStreamBuilder to manipulate $data property.


#### Why?

I am recently working on [Range Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) support
for my application. For a range request with multiple specified ranges, I need to return a "multipart/byteranges" **response**.
The signature of MultipartStreamBuilder::addResource forces me to add a field name ($name), which is totally non-sense for
my use case.

I tried to extend the MultipartStreamBuilder with my own class and have an extra method that can properly add
the streams without the unnecessary extra handling, but since the visibility of MultipartStreamBuilder::data is "private",
I cannot do that.


#### Example Usage

``` php

class MyBuilder extends MultipartStreamBuilder
{
    public function addStream($resource, array $options = [])
    {
        $options += ['headers' => []];
        $this->data[] = [
            'contents' => $this->createStream($resource),
            'headers' => $options['headers'],
        ];
    }
}

// If you added new features, show examples of how to use them here
// (remove this section if not a new feature)
$response = $resposneFactory->createResponse(416);

// Assuming I have to deal with a range request "Range: bytes=0-8192, 65536-131072"
$steam = (new MyBuilder($streamFactory))
  ->addPart(custom_splice_resource_func(fopen('/path/to/file1), 0, 8192), ['Content-Range', 'bytes 0-8192/8192'])
  ->addPart(custom_splice_resource_func(fopen('/path/to/file1), 65536, 131072), ['Content-Range', 'bytes 65536-131072/65536']);

// Emit the response to client
$emitter->emit($response->withBody($stream));
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
