### PR TITLE
Use temp stream instead of string to buffer content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0 - (unreleased)
 
 - Refactored MultipartStreamBuilder to clean up and allow injecting data without a filename
-- Dynamically use memory or temp file to buffer the stream content. Allow to stream content larger php memory limit.
+- Dynamically use memory or temp file to buffer the stream content.
 
 ## 1.1.2 - 2020-07-13
 
@@ -25,23 +25,23 @@ No changes from 0.2.0.
 ## 0.2.0 - 2017-02-20
 
 You may do a BC update to version 0.2.0 if you are sure that you are not adding
-multiple resources with the same name to the Builder. 
+multiple resources with the same name to the Builder.
 
 ### Fixed
 
-- Make sure one can add resources with same name without overwrite. 
+- Make sure one can add resources with same name without overwrite.
 
 ## 0.1.6 - 2017-02-16
 
 ### Fixed
 
-- Performance improvements by avoid using `uniqid()`. 
+- Performance improvements by avoid using `uniqid()`.
 
 ## 0.1.5 - 2017-02-14
 
 ### Fixed
 
-- Support for non-readable streams. This fix was needed because flaws in Guzzle, Zend and Slims implementations of PSR-7. 
+- Support for non-readable streams. This fix was needed because flaws in Guzzle, Zend and Slims implementations of PSR-7.
 
 ## 0.1.4 - 2016-12-31
 
@@ -53,7 +53,7 @@ multiple resources with the same name to the Builder.
 
 ### Added
 
-- Added `CustomMimetypeHelper` to allow you to configure custom mimetypes. 
+- Added `CustomMimetypeHelper` to allow you to configure custom mimetypes.
 
 ### Changed
 
@@ -63,13 +63,13 @@ multiple resources with the same name to the Builder.
 
 ### Added
 
-- Support for Outlook msg files. 
+- Support for Outlook msg files.
 
 ## 0.1.1 - 2016-08-10
 
 ### Added
 
-- Support for Apple passbook. 
+- Support for Apple passbook.
 
 ## 0.1.0 - 2016-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.2.0 - (unreleased)
 
 - Refactored MultipartStreamBuilder to clean up and allow injecting data without a filename
+- Dynamically use memory or temp file to buffer the stream content. Allow to stream content larger php memory limit.
 
 ## 1.1.2 - 2020-07-13
 

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -140,9 +140,7 @@ class MultipartStreamBuilder
             fwrite($buffer, "--{$this->getBoundary()}\r\n".
                 $this->getHeaders($data['headers'])."\r\n");
 
-            /**
-             * @var \Psr\Http\Message\StreamInterface
-             */
+            /** @var $contentStream StreamInterface */
             $contentStream = $data['contents'];
 
             // Read stream into buffer

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -39,6 +39,13 @@ class MultipartStreamBuilder
     private $data = [];
 
     /**
+     * @var int Bytes of unallocated memory to use for stream buffer.
+     * To have MultipartStreamBuilder manage it automatically, set to -1.
+     * Default: -1
+     */
+    private $bufferMaxMemory = -1;
+
+    /**
      * @param HttplugStreamFactory|StreamFactoryInterface|null $streamFactory
      */
     public function __construct($streamFactory = null)
@@ -133,10 +140,18 @@ class MultipartStreamBuilder
      */
     public function build()
     {
+        // Assign maximimum 1/4 php's available memory
+        // to attempt buffering the stream content.
+        // If the stream content exceed this, will fallback
+        // to use temporary file.
+        $maxmemory = ($this->bufferMaxMemory < 0)
+            ? \floor(static::getAvailableMemory() / 4)
+            : $this->bufferMaxMemory;
+
         // Open a temporary read-write stream as buffer.
         // If the size is less than predefined limit, things will stay in memory.
         // If the size is more than that, things will be stored in temp file.
-        $buffer = fopen('php://temp', 'r+');
+        $buffer = fopen('php://temp/maxmemory:' . $maxmemory, 'r+');
         foreach ($this->data as $data) {
             // Add start and headers
             fwrite($buffer, "--{$this->getBoundary()}\r\n".
@@ -357,5 +372,51 @@ class MultipartStreamBuilder
         }
 
         throw new \InvalidArgumentException(sprintf('First argument to "%s::createStream()" must be a string, resource or StreamInterface.', __CLASS__));
+    }
+
+    /**
+     * Setup the stream buffer size limit. PHP will allocate buffer
+     * in memory if the size of the stream is smaller than this size.
+     * Otherwise, PHP will store the stream data in a temporary file.
+     *
+     * @param integer $size
+     *     Size of stream data buffered (in bytes) until using temporary
+     *     file to buffer.
+     *
+     * @return MultipartStreamBuilder
+     */
+    public function setBufferMaxMemory(int $size): MultipartStreamBuilder
+    {
+        $this->bufferMaxMemory = $size;
+
+        return $this;
+    }
+
+    /**
+     * Get and parse memory_limit into bytes integer.
+     *
+     * @return integer
+     *
+     * @throws \Exception
+     *     If the ini format does not match expectation.
+     */
+    protected static function getAvailableMemory(): int
+    {
+        $memory_limit = ini_get('memory_limit');
+        if ($memory_limit === '-1') {
+            // If there is no memory limit, return 100MB by default.
+            return 100 * 1024 * 1024;
+        }
+        if (!preg_match('/^(\d+)(G|M|K|)$/', $memory_limit, $matches)) {
+            throw new \Exception("Unknown memory_limit format: {$memory_limit}");
+        }
+        if ($matches[2] == 'G') {
+            $memory_limit = $matches[1] * 1024 * 1024 * 1024; // nnnG -> nnn GB
+        } else if ($matches[2] == 'M') {
+            $memory_limit = $matches[1] * 1024 * 1024; // nnnM -> nnn MB
+        } else if ($matches[2] == 'K') {
+            $memory_limit = $matches[1] * 1024; // nnnK -> nnn KB
+        }
+        return (int) $memory_limit - \memory_get_usage();
     }
 }

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -149,13 +149,13 @@ class MultipartStreamBuilder
             }
             if ($contentStream->isReadable()) {
                 while (!$contentStream->eof()) {
-                    // read 1MB chunk into buffer until reached EOF.
+                    // Read 1MB chunk into buffer until reached EOF.
                     fwrite($buffer, $contentStream->read(1048576));
                 }
             } else {
-                // Try to getContents for non-readable stream.
-                // Less controllable chunk size (thus memory usage).
-                fwrite($buffer, $contentStream->getContents());
+                // If not isReadable, read from __toString().
+                // Warning: This could attempt to load a large amount of data into memory.
+                fwrite($buffer, $contentStream->__toString());
             }
             fwrite($buffer, "\r\n");
         }

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -40,8 +40,8 @@ class MultipartStreamBuilder
 
     /**
      * @var int Bytes of unallocated memory to use for stream buffer.
-     * To have MultipartStreamBuilder manage it automatically, set to -1.
-     * Default: -1
+     *          To have MultipartStreamBuilder manage it automatically, set to -1.
+     *          Default: -1
      */
     private $bufferMaxMemory = -1;
 
@@ -80,12 +80,10 @@ class MultipartStreamBuilder
     }
 
     /**
-     * Add a resource to the Multipart Stream
+     * Add a resource to the Multipart Stream.
      *
-     * @param string|resource|\Psr\Http\Message\StreamInterface $resource
-     *     The filepath, resource or StreamInterface of the data.
-     * @param array $headers
-     *     Additional headers array: ['header-name' => 'header-value'].
+     * @param string|resource|\Psr\Http\Message\StreamInterface $resource the filepath, resource or StreamInterface of the data
+     * @param array                                             $headers  additional headers array: ['header-name' => 'header-value']
      *
      * @return MultipartStreamBuilder
      */
@@ -151,7 +149,7 @@ class MultipartStreamBuilder
         // Open a temporary read-write stream as buffer.
         // If the size is less than predefined limit, things will stay in memory.
         // If the size is more than that, things will be stored in temp file.
-        $buffer = fopen('php://temp/maxmemory:' . $maxmemory, 'r+');
+        $buffer = fopen('php://temp/maxmemory:'.$maxmemory, 'r+');
         foreach ($this->data as $data) {
             // Add start and headers
             fwrite($buffer, "--{$this->getBoundary()}\r\n".
@@ -379,11 +377,8 @@ class MultipartStreamBuilder
      * in memory if the size of the stream is smaller than this size.
      * Otherwise, PHP will store the stream data in a temporary file.
      *
-     * @param integer $size
-     *     Size of stream data buffered (in bytes) until using temporary
-     *     file to buffer.
-     *
-     * @return MultipartStreamBuilder
+     * @param int $size size of stream data buffered (in bytes)
+     *                  until using temporary file to buffer
      */
     public function setBufferMaxMemory(int $size): MultipartStreamBuilder
     {
@@ -395,28 +390,26 @@ class MultipartStreamBuilder
     /**
      * Get and parse memory_limit into bytes integer.
      *
-     * @return integer
-     *
-     * @throws \Exception
-     *     If the ini format does not match expectation.
+     * @throws \Exception if the ini format does not match expectation
      */
     protected static function getAvailableMemory(): int
     {
         $memory_limit = ini_get('memory_limit');
-        if ($memory_limit === '-1') {
+        if ('-1' === $memory_limit) {
             // If there is no memory limit, return 100MB by default.
             return 100 * 1024 * 1024;
         }
         if (!preg_match('/^(\d+)(G|M|K|)$/', $memory_limit, $matches)) {
             throw new \Exception("Unknown memory_limit format: {$memory_limit}");
         }
-        if ($matches[2] == 'G') {
+        if ('G' === $matches[2]) {
             $memory_limit = $matches[1] * 1024 * 1024 * 1024; // nnnG -> nnn GB
-        } else if ($matches[2] == 'M') {
+        } elseif ('M' === $matches[2]) {
             $memory_limit = $matches[1] * 1024 * 1024; // nnnM -> nnn MB
-        } else if ($matches[2] == 'K') {
+        } elseif ('K' === $matches[2]) {
             $memory_limit = $matches[1] * 1024; // nnnK -> nnn KB
         }
+
         return (int) $memory_limit - \memory_get_usage();
     }
 }

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -388,7 +388,9 @@ class MultipartStreamBuilder
     }
 
     /**
-     * Get and parse memory_limit into bytes integer.
+     * Estimate the available memory in the system by php.ini memory_limit
+     * and memory_get_usage(). If memory_limit is "-1", the default estimation
+     * would be 100MB.
      *
      * @throws \Exception if the ini format does not match expectation
      */

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -153,8 +153,6 @@ class MultipartStreamBuilder
                     fwrite($buffer, $contentStream->read(1048576));
                 }
             } else {
-                // If not isReadable, read from __toString().
-                // Warning: This could attempt to load a large amount of data into memory.
                 fwrite($buffer, $contentStream->__toString());
             }
             fwrite($buffer, "\r\n");


### PR DESCRIPTION
* Update MultipartStreamBuilder::build to buffer built content
  in a php://temp stream resource instead of (string) $contents.
  This way, the size of the stream built won't be limited by PHP
  runtime limit.

| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   | Fully backward compatible without any interface changes. Only internal programming changes.
| License         | MIT


#### What's in this PR?

Rewrite to append stream contents and boundaries into a ["php://temp"](https://www.php.net/manual/en/wrappers.php.php) stream as a buffer. Contents within predefined limit (2MB) will be handled in memory for speed. Otherwise, PHP will create a temp file for storage. This mean the multipart stream size is virtually without size limit (unless if, of course, your harddisk is full).


#### Why?

The original MultipartStreamBuilder::build would read everything into a string variable `$streams` before making it another stream. If the total size of the content exceed the PHP's memory limit, the process would fail.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [x] Documentation pull request created (if not simply a bugfix)