### PR TITLE
Fix styleci config issue

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -7,8 +7,5 @@ finder:
     path:
         - "src"
 
-enabled:
-    - short_array_syntax
-
 disabled:
     - single_line_throw


### PR DESCRIPTION
* Fix this issue from the styleci platform:
  "Config Issue: The 'short_array_syntax' fixer cannot be enabled again because it has already been enabled."

| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| Documentation   | Fix StyleCI issue with the current configuration
| License         | MIT


#### What's in this PR?

Remove "short_array_syntax" from "enabled".


#### Why?

To fix this:

![2020-12-22 23-14-56 的螢幕擷圖](https://user-images.githubusercontent.com/91274/102903722-b1eb0d00-44ab-11eb-8002-06a688d1d1e8.png)


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
