### PR TITLE
Also skip setting filename if URI starts with `data://`

### DIFF
--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -114,7 +114,7 @@ class MultipartStreamBuilder
         if (empty($options['filename'])) {
             $options['filename'] = null;
             $uri = $stream->getMetadata('uri');
-            if ('php://' !== substr($uri, 0, 6)) {
+            if ('php://' !== substr($uri, 0, 6) && 'data://' !== substr($uri, 0, 7)) {
                 $options['filename'] = $uri;
             }
         }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | .
| Documentation   | .
| License         | MIT


#### What's in this PR?

Avoid implicitly setting potentially very large `data://...` as the filename.


#### Why?

See https://github.com/guzzle/psr7/issues/472.


#### Example Usage


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
