### PR TITLE
Allow `psr/http-message` v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
         "php-http/message-factory": "^1.0.2",
         "php-http/discovery": "^1.7"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| Documentation   | -
| License         | MIT


#### What's in this PR?

Adds support for `psr/http-message` v2, similar to https://github.com/php-http/message-factory/pull/42.


#### Why?

Latest version.


#### Example Usage

N/A


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do

- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
