### PR TITLE
add `webp` mimetype

### DIFF
--- a/src/ApacheMimetypeHelper.php
+++ b/src/ApacheMimetypeHelper.php
@@ -113,6 +113,7 @@ class ApacheMimetypeHelper implements MimetypeHelper
             'ttf' => 'application/x-font-ttf',
             'txt' => 'text/plain',
             'wav' => 'audio/x-wav',
+            'webp' => 'image/webp',
             'webm' => 'video/webm',
             'wma' => 'audio/x-ms-wma',
             'wmv' => 'video/x-ms-wmv',


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |  /
| Documentation   | /
| License         | MIT


#### What's in this PR?

This adds the mimetype `webp` to `src/ApacheMimetypeHelper.php`

#### Why?

This is used to create a proxy between  front and back-end system. 
When uploading `webp` files via this proxy the mimetype isn't passed on.

