### PR TITLE
fix: Remove default content-length header from MultipartStreamBuilder class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## 1.3.2 - 2024-08-10
+## 1.4.0 - 2024-09-01
 
-- Remove default `Content-Length` header from MultipartStreamBuilder class.
+- No longer automatically add a `Content-Length` header for each part in MultipartStreamBuilder class to comply with RFC 7578 section 4.8.
 
 ## 1.3.1 - 2024-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.3.2 - 2024-08-10
+
+- Remove default `Content-Length` header from MultipartStreamBuilder class.
+
 ## 1.3.1 - 2024-06-10
 
 - Added missing mimetype for `.webp` images.

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -95,9 +95,9 @@ class MultipartStreamBuilder
      * @param string|resource|StreamInterface $resource
      * @param array                           $options  {
      *
-     *     @var array  $headers additional headers ['header-name' => 'header-value']
-     *     @var string $filename
-     * }
+     * @var array  $headers additional headers ['header-name' => 'header-value']
+     * @var string $filename
+     *             }
      *
      * @return MultipartStreamBuilder
      */

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -95,9 +95,9 @@ class MultipartStreamBuilder
      * @param string|resource|StreamInterface $resource
      * @param array                           $options  {
      *
-     * @var array  $headers additional headers ['header-name' => 'header-value']
-     * @var string $filename
-     *             }
+     *     @var array  $headers additional headers ['header-name' => 'header-value']
+     *     @var string $filename
+     * }
      *
      * @return MultipartStreamBuilder
      */

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -95,9 +95,9 @@ class MultipartStreamBuilder
      * @param string|resource|StreamInterface $resource
      * @param array                           $options  {
      *
-     *     @var array $headers additional headers ['header-name' => 'header-value']
-     *     @var string $filename
-     * }
+     * @var array  $headers additional headers ['header-name' => 'header-value']
+     * @var string $filename
+     *             }
      *
      * @return MultipartStreamBuilder
      */
@@ -182,13 +182,6 @@ class MultipartStreamBuilder
             $headers['Content-Disposition'] = sprintf('form-data; name="%s"', $name);
             if ($hasFilename) {
                 $headers['Content-Disposition'] .= sprintf('; filename="%s"', $this->basename($filename));
-            }
-        }
-
-        // Set a default content-length header if one was not provided
-        if (!$this->hasHeader($headers, 'content-length')) {
-            if ($length = $stream->getSize()) {
-                $headers['Content-Length'] = (string) $length;
             }
         }
 

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -88,13 +88,13 @@ class FunctionTest extends TestCase
         $this->assertTrue(false === strpos($multipartStream, 'Content-Disposition:'));
     }
 
-    public function testContentLength()
+    public function testShouldNotContainContentLength()
     {
         $builder = new MultipartStreamBuilder();
         $builder->addResource('foobar', 'stream contents');
 
         $multipartStream = (string) $builder->build();
-        $this->assertTrue(false !== strpos($multipartStream, 'Content-Length: 15'));
+        $this->assertTrue(false === strpos($multipartStream, 'Content-Length: 15'));
     }
 
     public function testFormName()

--- a/tests/FunctionTest.php
+++ b/tests/FunctionTest.php
@@ -88,13 +88,16 @@ class FunctionTest extends TestCase
         $this->assertTrue(false === strpos($multipartStream, 'Content-Disposition:'));
     }
 
+    /**
+     * Comply with RFC 7578 section 4.8
+     */
     public function testShouldNotContainContentLength()
     {
         $builder = new MultipartStreamBuilder();
         $builder->addResource('foobar', 'stream contents');
 
         $multipartStream = (string) $builder->build();
-        $this->assertTrue(false === strpos($multipartStream, 'Content-Length: 15'));
+        $this->assertTrue(false === strpos($multipartStream, 'Content-Length:'));
     }
 
     public function testFormName()


### PR DESCRIPTION


| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| Documentation   | N/A
| License         | MIT


#### What's in this PR?

Remove default `Content-Length` header from MultipartStreamBuilder class.

#### Why?

`Content-Length` in multipart bodies is not necessary. Some legacies system can't manage the "Content-Length" header into "multipart/form-data" boundary and cut off the request.

Currently I had face this problem with Azure OpenAI upload files API.

For reference see the RFC 7578 in section 4.8 which specify:

4.8. Other "Content-" Header Fields

The multipart/form-data media type does not support any MIME header
fields in parts other than Content-Type, Content-Disposition, and (in
limited circumstances) Content-Transfer-Encoding. **Other header
fields MUST NOT be included and MUST be ignored**.

Older system are not compliant because not apply the MUST be ignore policy but on the other side this code non apply the MUST NOT be included policy. So the Azure OpenAI API server is designed to be RFC compliant.

#### Example Usage

N/A

#### Checklist

- [X] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [X] Documentation pull request created (if not simply a bugfix)
