### PR TITLE
Make options optional again

### DIFF
--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -93,8 +93,8 @@ class MultipartStreamBuilder
      *
      * @param string                                                      $name     the formpost name
      * @param string|resource|StreamInterface                             $resource
-     * @param array{'headers': array<string, string>, 'filename': string} $options
-     *
+     * @param array{'headers?': array<string, string>, 'filename?': string} $options
+     
      * Options:
      * - headers: additional headers as hashmap ['header-name' => 'header-value']
      * - filename: used to determine the mime type

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -91,8 +91,8 @@ class MultipartStreamBuilder
     /**
      * Add a resource to the Multipart Stream.
      *
-     * @param string                                                      $name     the formpost name
-     * @param string|resource|StreamInterface                             $resource
+     * @param string                                                        $name     the formpost name
+     * @param string|resource|StreamInterface                               $resource
      * @param array{'headers?': array<string, string>, 'filename?': string} $options
      *
      * Options:

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -94,7 +94,7 @@ class MultipartStreamBuilder
      * @param string                                                      $name     the formpost name
      * @param string|resource|StreamInterface                             $resource
      * @param array{'headers?': array<string, string>, 'filename?': string} $options
-     
+     *
      * Options:
      * - headers: additional headers as hashmap ['header-name' => 'header-value']
      * - filename: used to determine the mime type


### PR DESCRIPTION
This was done incorrectly in #65
/cc @dbu 

> Parameter #3 $options of method Http\Message\MultipartStream\MultipartStreamBuilder::addResource() expects array{headers: array<string, string>, filename: string}, array{filename: string} given.