### PR TITLE
Unquote array shape field names

### DIFF
--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -91,8 +91,8 @@ class MultipartStreamBuilder
     /**
      * Add a resource to the Multipart Stream.
      *
-     * @param string                                                        $name     the formpost name
-     * @param string|resource|StreamInterface                               $resource
+     * @param string                                                    $name     the formpost name
+     * @param string|resource|StreamInterface                           $resource
      * @param array{headers?: array<string, string>, filename?: string} $options
      *
      * Options:

--- a/src/MultipartStreamBuilder.php
+++ b/src/MultipartStreamBuilder.php
@@ -93,7 +93,7 @@ class MultipartStreamBuilder
      *
      * @param string                                                        $name     the formpost name
      * @param string|resource|StreamInterface                               $resource
-     * @param array{'headers?': array<string, string>, 'filename?': string} $options
+     * @param array{headers?: array<string, string>, filename?: string} $options
      *
      * Options:
      * - headers: additional headers as hashmap ['header-name' => 'header-value']


### PR DESCRIPTION
Otherwise optionals don't work.

See #66
